### PR TITLE
SOC-5361: add relationship between Connection and IdentityEntity

### DIFF
--- a/lib/src/main/java/org/exoplatform/social/addons/search/ProfileIndexingServiceConnector.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/search/ProfileIndexingServiceConnector.java
@@ -109,10 +109,10 @@ public class ProfileIndexingServiceConnector extends ElasticIndexingServiceConne
     StringBuilder sb = new StringBuilder();
     String identityId = identity.getId();
     for(Connection con : connections) {
-      if (identityId.equals(con.getSenderId())) {
-        sb.append(con.getReceiverId()).append(",");
+      if (identityId.equals(con.getSender().getStringId())) {
+        sb.append(con.getReceiver().getStringId()).append(",");
       } else {
-        sb.append(con.getSenderId()).append(",");
+        sb.append(con.getSender().getStringId()).append(",");
       }
     }
     //Remove the last ","

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/RDBMSIdentityStorageImpl.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/RDBMSIdentityStorageImpl.java
@@ -132,7 +132,7 @@ public class RDBMSIdentityStorageImpl extends IdentityStorageImpl {
       return null;
     }
 
-    Identity identity = new Identity(String.valueOf(entity.getId()));
+    Identity identity = new Identity(entity.getStringId());
     mapToIdentity(entity, identity);
     return identity;
   }
@@ -351,7 +351,7 @@ public class RDBMSIdentityStorageImpl extends IdentityStorageImpl {
     } else {
       entity = getIdentityDAO().create(entity);
     }
-    identity.setId(String.valueOf(entity.getId()));
+    identity.setId(entity.getStringId());
   }
 
   /**
@@ -450,7 +450,7 @@ public class RDBMSIdentityStorageImpl extends IdentityStorageImpl {
 
     // Delete all connection
     query = em.createNamedQuery("SocConnection.deleteConnectionByIdentity");
-    query.setParameter("identityId", String.valueOf(id));
+    query.setParameter("identityId", id);
     query.executeUpdate();
 
     if(OrganizationIdentityProvider.NAME.equals(provider)) {
@@ -872,7 +872,7 @@ public class RDBMSIdentityStorageImpl extends IdentityStorageImpl {
 
     // Delete all connection
     query = em.createNamedQuery("SocConnection.deleteConnectionByIdentity");
-    query.setParameter("identityId", String.valueOf(id));
+    query.setParameter("identityId", id);
     query.executeUpdate();
 
     if(OrganizationIdentityProvider.NAME.equals(provider)) {

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/ConnectionDAO.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/ConnectionDAO.java
@@ -51,6 +51,8 @@ public interface ConnectionDAO extends GenericDAO<Connection, Long> {
    */
   Connection getConnection(Identity identity1, Identity identity2);
 
+  Connection getConnection(Long sender, Long receiver);
+
   
   /**
    * @param identity

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/ConnectionDAOImpl.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/ConnectionDAOImpl.java
@@ -66,6 +66,20 @@ public class ConnectionDAOImpl extends GenericDAOJPAImpl<Connection, Long> imple
   }
 
   @Override
+  public Connection getConnection(Long sender, Long reciver) {
+    TypedQuery<Connection> query = getEntityManager().createNamedQuery("SocConnection.findConnectionBySenderAndReceiver", Connection.class);
+    query.setParameter("sender", sender);
+    query.setParameter("reciver", reciver);
+    query.setMaxResults(1);
+
+    try {
+      return query.getSingleResult();
+    } catch (NoResultException ex) {
+      return null;
+    }
+  }
+
+  @Override
   public List<Connection> getConnections(Identity identity, Type type, long offset, long limit) {
     return RelationshipQueryBuilder.builder()
                                    .owner(identity)

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/query/AStreamQueryBuilder.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/query/AStreamQueryBuilder.java
@@ -38,6 +38,7 @@ import org.exoplatform.social.addons.storage.entity.Activity;
 import org.exoplatform.social.addons.storage.entity.Activity_;
 import org.exoplatform.social.addons.storage.entity.Connection;
 import org.exoplatform.social.addons.storage.entity.Connection_;
+import org.exoplatform.social.addons.storage.entity.IdentityEntity_;
 import org.exoplatform.social.addons.storage.entity.StreamItem;
 import org.exoplatform.social.addons.storage.entity.StreamItem_;
 import org.exoplatform.social.addons.storage.entity.StreamType;
@@ -222,16 +223,17 @@ public final class AStreamQueryBuilder {
     }
     
     if (this.myIdentity != null) {
+      long identityId = Long.valueOf(this.myIdentity.getId());
       Root<Connection> subRoot1 = subQuery1.from(Connection.class);
 
-      Path receiver = subRoot1.get(Connection_.receiverId);
-      Path sender = subRoot1.get(Connection_.senderId);
+      Path receiver = subRoot1.get(Connection_.receiver).get(IdentityEntity_.id);
+      Path sender = subRoot1.get(Connection_.sender).get(IdentityEntity_.id);
 
       CriteriaBuilder.Case select = cb.selectCase();
-      select.when(cb.equal(receiver, myIdentity.getId()), sender).otherwise(receiver);
+      select.when(cb.equal(receiver, identityId), sender).otherwise(receiver);
 
-      subQuery1.select(select);
-      subQuery1.where(cb.and(cb.or(cb.equal(sender, this.myIdentity.getId()), cb.equal(receiver, this.myIdentity.getId())),
+      subQuery1.select(select.as(String.class));
+      subQuery1.where(cb.and(cb.or(cb.equal(sender, identityId), cb.equal(receiver, identityId)),
               cb.equal(subRoot1.<Relationship.Type>get(Connection_.status), Relationship.Type.CONFIRMED)));
 
       Predicate posterConnection = cb.and(cb.in(stream.get(StreamItem_.ownerId)).value(subQuery1), cb.equal(stream.get(StreamItem_.streamType), StreamType.POSTER));
@@ -292,17 +294,18 @@ public final class AStreamQueryBuilder {
     }
 
     if (this.myIdentity != null) {
-      
+
+      long identityId = Long.valueOf(this.myIdentity.getId());
       Root<Connection> subRoot1 = subQuery1.from(Connection.class);
 
-      Path receiver = subRoot1.get(Connection_.receiverId);
-      Path sender = subRoot1.get(Connection_.senderId);
+      Path receiver = subRoot1.get(Connection_.receiver).get(IdentityEntity_.id);
+      Path sender = subRoot1.get(Connection_.sender).get(IdentityEntity_.id);
 
       CriteriaBuilder.Case select = cb.selectCase();
-      select.when(cb.equal(sender, myIdentity.getId()), receiver).otherwise(sender);
+      select.when(cb.equal(sender, identityId), receiver).otherwise(sender);
 
-      subQuery1.select(select);
-      subQuery1.where(cb.and(cb.or(cb.equal(sender, this.myIdentity.getId()), cb.equal(receiver, this.myIdentity.getId())),
+      subQuery1.select(select.as(String.class));
+      subQuery1.where(cb.and(cb.or(cb.equal(sender, identityId), cb.equal(receiver, identityId)),
                              cb.equal(subRoot1.<Relationship.Type> get(Connection_.status), Relationship.Type.CONFIRMED)));
       
       predicates.add(cb.and(cb.in(stream.get(StreamItem_.ownerId)).value(subQuery1), cb.equal(stream.get(StreamItem_.streamType), StreamType.POSTER)));

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/query/RelationshipQueryBuilder.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/query/RelationshipQueryBuilder.java
@@ -33,6 +33,7 @@ import javax.persistence.criteria.Root;
 import org.exoplatform.commons.persistence.impl.EntityManagerHolder;
 import org.exoplatform.social.addons.storage.entity.Connection;
 import org.exoplatform.social.addons.storage.entity.Connection_;
+import org.exoplatform.social.addons.storage.entity.IdentityEntity_;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.relationship.model.Relationship;
@@ -102,8 +103,8 @@ public final class RelationshipQueryBuilder {
     
     Predicate predicate = null;
     if (this.sender != null && this.receiver != null) {
-      predicate = cb.equal(connection.get(Connection_.senderId), sender.getId()) ;
-      predicate = cb.and(predicate, cb.equal(connection.get(Connection_.receiverId), receiver.getId()));
+      predicate = cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(sender.getId())) ;
+      predicate = cb.and(predicate, cb.equal(connection.get(Connection_.receiver).get(IdentityEntity_.id), Long.valueOf(receiver.getId())));
     }
     
     CriteriaQuery<Connection> select = criteria.select(connection).distinct(true);
@@ -124,19 +125,19 @@ public final class RelationshipQueryBuilder {
     Root<Connection> connection = criteria.from(Connection.class);
 
     List<Predicate> predicates = new ArrayList<>();
-    Path sender = connection.get(Connection_.senderId);
-    Path receiver = connection.get(Connection_.receiverId);
+    Path sender = connection.get(Connection_.sender).get(IdentityEntity_.id);
+    Path receiver = connection.get(Connection_.receiver).get(IdentityEntity_.id);
 
     //owner
     if (this.owner != null) {
       Predicate predicate = null;
       if (this.status == Type.OUTGOING) {
-        predicate = cb.equal(sender, owner.getId());
+        predicate = cb.equal(sender, Long.valueOf(owner.getId()));
       } else if (this.status == Type.INCOMING) {
-        predicate = cb.equal(receiver, owner.getId());
+        predicate = cb.equal(receiver, Long.valueOf(owner.getId()));
       } else {
-        predicate = cb.or(cb.equal(sender, owner.getId()),
-                cb.equal(receiver, owner.getId()));
+        predicate = cb.or(cb.equal(sender, Long.valueOf(owner.getId())),
+                cb.equal(receiver, Long.valueOf(owner.getId())));
       }
       predicates.add(predicate);
     }
@@ -150,10 +151,10 @@ public final class RelationshipQueryBuilder {
     }
 
     if (this.sender != null) {
-      predicates.add(cb.equal(sender, this.sender.getId()));
+      predicates.add(cb.equal(sender, Long.valueOf(this.sender.getId())));
     }
     if (this.receiver != null) {
-      predicates.add(cb.equal(receiver, this.receiver.getId()));
+      predicates.add(cb.equal(receiver, Long.valueOf(this.receiver.getId())));
     }
     
     CriteriaQuery<Connection> select = criteria.select(connection).distinct(true);
@@ -182,12 +183,12 @@ public final class RelationshipQueryBuilder {
     //owner
     if (this.owner != null) {
       if (this.status == Type.OUTGOING) {
-        predicate = cb.equal(connection.get(Connection_.senderId), owner.getId());
+        predicate = cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(owner.getId()));
       } else if (this.status == Type.INCOMING) {
-        predicate = cb.equal(connection.get(Connection_.receiverId), owner.getId());
+        predicate = cb.equal(connection.get(Connection_.receiver).get(IdentityEntity_.id), Long.valueOf(owner.getId()));
       } else {
-        predicate = cb.or(cb.equal(connection.get(Connection_.senderId), owner.getId()),
-                cb.equal(connection.get(Connection_.receiverId), owner.getId()));
+        predicate = cb.or(cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(owner.getId())),
+                cb.equal(connection.get(Connection_.receiver).get(IdentityEntity_.id), Long.valueOf(owner.getId())));
       }
     }
     //status
@@ -215,12 +216,12 @@ public final class RelationshipQueryBuilder {
     //owner
     if (this.owner != null) {
       if (this.status == Type.OUTGOING) {
-        predicate = cb.equal(connection.get(Connection_.senderId), owner.getId());
+        predicate = cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(owner.getId()));
       } else if (this.status == Type.INCOMING) {
-        predicate = cb.equal(connection.get(Connection_.receiverId), owner.getId());
+        predicate = cb.equal(connection.get(Connection_.receiver).get(IdentityEntity_.id), Long.valueOf(owner.getId()));
       } else {
-        predicate = cb.or(cb.equal(connection.get(Connection_.senderId), owner.getId()),
-                cb.equal(connection.get(Connection_.receiverId), owner.getId()));
+        predicate = cb.or(cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(owner.getId())),
+                cb.equal(connection.get(Connection_.receiver).get(IdentityEntity_.id), Long.valueOf(owner.getId())));
       }
     }
     //status
@@ -280,7 +281,7 @@ public final class RelationshipQueryBuilder {
     Predicate predicate = null;
     // owner
     if (this.owner != null) {
-      predicate = cb.equal(connection.get(Connection_.senderId), owner.getId());
+      predicate = cb.equal(connection.get(Connection_.sender).get(IdentityEntity_.id), Long.valueOf(owner.getId()));
     }
     // status
     if (this.status != null) {
@@ -292,9 +293,9 @@ public final class RelationshipQueryBuilder {
     //Exclude identities
       List<Identity> excludedIdentityList = profileFilter.getExcludedIdentityList();
       if (excludedIdentityList != null && excludedIdentityList.size() > 0) {
-        In<String> in = cb.in(connection.get(Connection_.receiverId));
+        In<Long> in = cb.in(connection.get(Connection_.receiver).get(IdentityEntity_.id));
         for (Identity id : excludedIdentityList) {
-          in.value(id.getId());
+          in.value(Long.valueOf(id.getId()));
         }
         predicate = cb.and(predicate, in.not());  
       }

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/entity/Connection.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/entity/Connection.java
@@ -12,10 +12,12 @@ import javax.persistence.*;
 @NamedQueries({
         @NamedQuery(name = "getRelationships",
                 query = "select r from Connection r"),
+        @NamedQuery(name = "SocConnection.findConnectionBySenderAndReceiver",
+                query = "SELECT c FROM Connection c WHERE c.sender.id = :sender AND c.receiver.id = :reciver"),
         @NamedQuery(name = "SocConnection.deleteConnectionByIdentity",
-                query = "DELETE FROM Connection c WHERE c.senderId = :identityId OR c.receiverId = :identityId"),
-        @NamedQuery(name = "SocConnection.migrateSenderId", query = "UPDATE Connection c SET c.senderId = :newId WHERE c.senderId = :oldId"),
-        @NamedQuery(name = "SocConnection.migrateReceiverId", query = "UPDATE Connection c SET c.receiverId = :newId WHERE c.receiverId = :oldId")
+                query = "DELETE FROM Connection c WHERE c.sender.id = :identityId OR c.receiver.id = :identityId"),
+        @NamedQuery(name = "SocConnection.migrateSenderId", query = "UPDATE Connection c SET c.sender.id = :newId WHERE c.sender.id = :oldId"),
+        @NamedQuery(name = "SocConnection.migrateReceiverId", query = "UPDATE Connection c SET c.receiver.id = :newId WHERE c.receiver.id = :oldId")
 })
 public class Connection {
 
@@ -25,11 +27,13 @@ public class Connection {
   @Column(name = "CONNECTION_ID")
   private Long id;
 
-  @Column(name="SENDER_ID", length = 36, nullable = false)
-  private String senderId;
-  
-  @Column(name="RECEIVER_ID", length = 36, nullable = false)
-  private String receiverId;
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "SENDER_ID", referencedColumnName = "IDENTITY_ID")
+  private IdentityEntity sender;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "RECEIVER_ID", referencedColumnName = "IDENTITY_ID")
+  private IdentityEntity receiver;
   
   @Enumerated
   @Column(name="STATUS", nullable = false)
@@ -42,10 +46,9 @@ public class Connection {
   public Connection() {
   }
 
-  public Connection(String senderId, String receiverId, Type status) {
-    this.senderId = senderId;
-    this.receiverId = receiverId;
-    this.status = status;
+  public Connection(IdentityEntity sender, IdentityEntity receiver) {
+    this.sender = sender;
+    this.receiver = receiver;
   }
 
   public Long getId() {
@@ -56,20 +59,20 @@ public class Connection {
     this.id = id;
   }
 
-  public String getSenderId() {
-    return senderId;
+  public IdentityEntity getSender() {
+    return sender;
   }
 
-  public void setSenderId(String senderId) {
-    this.senderId = senderId;
+  public void setSender(IdentityEntity sender) {
+    this.sender = sender;
   }
 
-  public String getReceiverId() {
-    return receiverId;
+  public IdentityEntity getReceiver() {
+    return receiver;
   }
 
-  public void setReceiverId(String receiverId) {
-    this.receiverId = receiverId;
+  public void setReceiver(IdentityEntity receiver) {
+    this.receiver = receiver;
   }
 
   public Type getStatus() {

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/entity/IdentityEntity.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/entity/IdentityEntity.java
@@ -30,9 +30,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
@@ -77,8 +80,18 @@ public class IdentityEntity {
   @OneToOne(mappedBy = "identity", fetch = FetchType.LAZY, orphanRemoval = true)
   private ProfileEntity profile;
 
+  @OneToMany(mappedBy = "receiver", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE}, orphanRemoval = true)
+  private List<Connection> incomingConnections;
+
+  @OneToMany(mappedBy = "sender", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE}, orphanRemoval = true)
+  private List<Connection> outgoingConnections;
+
   public long getId() {
     return id;
+  }
+
+  public String getStringId() {
+    return String.valueOf(id);
   }
 
   public void setId(long id) {

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/RDBMSMigrationManager.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/RDBMSMigrationManager.java
@@ -119,27 +119,28 @@ public class RDBMSMigrationManager implements Startable {
             LOG.info("START ASYNC MIGRATION---------------------------------------------------");
             //
             if (!MigrationContext.isDone()) {
-              if (!MigrationContext.isConnectionDone()) {
-                relationshipMigration = CommonsUtils.getService(RelationshipMigrationService.class);
-                relationshipMigration.start();
-                updateSettingValue(MigrationContext.SOC_RDBMS_CONNECTION_MIGRATION_KEY, MigrationContext.isConnectionDone());
-              }
-              if (!MigrationContext.isDone() && MigrationContext.isConnectionDone() && !MigrationContext.isActivityDone()) {
+              if (!MigrationContext.isDone() && !MigrationContext.isActivityDone()) {
                 getActivityMigrationService().start();
                 updateSettingValue(MigrationContext.SOC_RDBMS_ACTIVITY_MIGRATION_KEY, MigrationContext.isActivityDone());
               }
-              if (!MigrationContext.isDone() && MigrationContext.isConnectionDone() && MigrationContext.isActivityDone() 
+              if (!MigrationContext.isDone() && MigrationContext.isActivityDone()
                   && !MigrationContext.isSpaceDone()) {
                 getSpaceMigrationService().start();
                 updateSettingValue(MigrationContext.SOC_RDBMS_SPACE_MIGRATION_KEY, MigrationContext.isSpaceDone());
               }
 
               // Migrate identities
-              if (!MigrationContext.isDone() && MigrationContext.isConnectionDone()
+              if (!MigrationContext.isDone()
                       && MigrationContext.isActivityDone() && MigrationContext.isSpaceDone()
                       && !MigrationContext.isIdentityDone()) {
                 getIdentityMigrationService().start();
                 updateSettingValue(MigrationContext.SOC_RDBMS_IDENTITY_MIGRATION_KEY, MigrationContext.isIdentityDone());
+              }
+
+              if (!MigrationContext.isDone() && MigrationContext.isIdentityDone() && !MigrationContext.isConnectionDone()) {
+                relationshipMigration = CommonsUtils.getService(RelationshipMigrationService.class);
+                relationshipMigration.start();
+                updateSettingValue(MigrationContext.SOC_RDBMS_CONNECTION_MIGRATION_KEY, MigrationContext.isConnectionDone());
               }
             }
 

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/listener/IdentityReferenceUpdaterListener.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/listener/IdentityReferenceUpdaterListener.java
@@ -49,17 +49,6 @@ public class IdentityReferenceUpdaterListener extends Listener<Identity, String>
 
     Query query;
 
-    // Update Connection
-    query = em.createNamedQuery("SocConnection.migrateSenderId");
-    query.setParameter("newId", newId);
-    query.setParameter("oldId", oldId);
-    query.executeUpdate();
-
-    query = em.createNamedQuery("SocConnection.migrateReceiverId");
-    query.setParameter("newId", newId);
-    query.setParameter("oldId", oldId);
-    query.executeUpdate();
-
     // Update activity poster
     query = em.createNamedQuery("SocActivity.migratePosterId");
     query.setParameter("newId", newId);

--- a/lib/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/lib/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -174,37 +174,6 @@
             <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
         </modifySql>
     </changeSet>
-    <changeSet author="social" id="1.0.0-7">
-        <createTable tableName="SOC_CONNECTIONS">
-            <column name="CONNECTION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
-              <constraints nullable="false" primaryKey="true" primaryKeyName="PK_SOC_CONNECTIONS"/>
-            </column>
-            <column name="RECEIVER_ID" type="NVARCHAR(36)">
-              <constraints nullable="false"/>
-            </column>
-            <column name="SENDER_ID" type="NVARCHAR(36)">
-              <constraints nullable="false"/>
-            </column>
-            <column name="STATUS" type="INT">
-              <constraints nullable="false"/>
-            </column>
-            <column name="LAST_UPDATED" type="BIGINT">
-              <constraints nullable="false"/>
-            </column>
-        </createTable>
-        <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_01">
-            <column name="RECEIVER_ID"/>
-        </createIndex>
-        <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_02">
-            <column name="SENDER_ID"/>
-        </createIndex>
-        <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_03">
-            <column name="LAST_UPDATED" descending="true"/>
-        </createIndex>
-        <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_04">
-            <column name="STATUS"/>
-        </createIndex>
-    </changeSet>
     <changeSet author="social" id="1.0.0-8">
         <createTable tableName="SOC_STREAM_ITEMS">
             <column name="STREAM_ITEM_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
@@ -455,5 +424,37 @@
                          constraintName="UK_SPACE_USER_STATUS_01"
                          tableName="SOC_SPACES_MEMBERS"/>                         
     <addPrimaryKey columnNames="PROFILE_ID, NAME" constraintName="PK_SOC_PROFILE_PROPERTY_01" tableName="SOC_IDENTITY_PROFILE_PROPERTY"/>                                                    
+  </changeSet>
+
+  <changeSet author="social" id="1.0.0-34">
+    <createTable tableName="SOC_CONNECTIONS">
+      <column name="CONNECTION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_SOC_CONNECTIONS"/>
+      </column>
+      <column name="SENDER_ID" type="BIGINT">
+        <constraints foreignKeyName="FK_SOC_CONNECTION_SENDER" references="SOC_IDENTITY(IDENTITY_ID)" nullable="false"/>
+      </column>
+      <column name="RECEIVER_ID" type="BIGINT">
+        <constraints foreignKeyName="FK_SOC_CONNECTION_RECEIVER" references="SOC_IDENTITY(IDENTITY_ID)" nullable="false"/>
+      </column>
+      <column name="STATUS" type="INT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="LAST_UPDATED" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_01">
+      <column name="RECEIVER_ID"/>
+    </createIndex>
+    <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_02">
+      <column name="SENDER_ID"/>
+    </createIndex>
+    <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_03">
+      <column name="LAST_UPDATED" descending="true"/>
+    </createIndex>
+    <createIndex tableName="SOC_CONNECTIONS" indexName="IDX_SOC_CONNECTIONS_04">
+      <column name="STATUS"/>
+    </createIndex>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
In this PR we add the relationship between JPA entities: Connection and IdentityEntity Then we will use join query instead of sub-query when retrieve connections of an user.