### PR TITLE
SOC-5506 : change type of column SOC_ACTIVITY_TEMPLATE_PARAMS.TEMPLATE_PARAM_VALUE to LONGTEXT

### DIFF
--- a/lib/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
+++ b/lib/src/main/resources/db/changelog/social-rdbms.db.changelog-1.0.0.xml
@@ -425,4 +425,8 @@
     </createIndex>
   </changeSet>
 
+  <changeSet author="social" id="1.0.0-42">
+    <modifyDataType tableName="SOC_ACTIVITY_TEMPLATE_PARAMS" columnName="TEMPLATE_PARAM_VALUE" newDataType="LONGTEXT"/>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
I propose to change type of SOC_ACTIVITY_TEMPLATE_PARAMS.TEMPLATE_PARAM_VALUE to LONGTEXT since it can contain long text and it makes it consistent with SOC_ACTIVITIES.TITLE.