### PR TITLE
SOC-5514 Space activities are lost after migration when the JCR space identity node has a name not equal to remoteId

### DIFF
--- a/lib/src/main/java/org/exoplatform/social/addons/storage/RDBMSSpaceStorageImpl.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/RDBMSSpaceStorageImpl.java
@@ -445,7 +445,7 @@ public class RDBMSSpaceStorageImpl extends SpaceStorageImpl implements SpaceStor
       }
 
       //
-      LOG.debug(String.format("Space %s (%s) saved", space.getPrettyName(), space.getId()));
+      LOG.debug("Space  id={} name={} saved", space.getId(), space.getPrettyName());
 
     } catch (NodeNotFoundException e) {
       throw new SpaceStorageException(SpaceStorageException.Type.FAILED_TO_RENAME_SPACE, e.getMessage(), e);
@@ -475,7 +475,7 @@ public class RDBMSSpaceStorageImpl extends SpaceStorageImpl implements SpaceStor
       }
     }
 
-    LOG.debug("Space {} ({}) saved", space.getPrettyName(), space.getId());
+    LOG.debug("Space id={} name={} saved", space.getId(), space.getPrettyName());
   }
 
   @Override

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/IdentityDAOImpl.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/IdentityDAOImpl.java
@@ -42,7 +42,7 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
   public IdentityEntity create(IdentityEntity entity) {
     IdentityEntity exists = findByProviderAndRemoteId(entity.getProviderId(), entity.getRemoteId());
     if (exists != null) {
-      throw new EntityExistsException("Identity is existed with ProviderID=" + entity.getProviderId() + " and RemoteId=" + entity.getRemoteId());
+      throw new EntityExistsException("Identity already exists provider_id=" + entity.getProviderId() + " remote_id=" + entity.getRemoteId());
     }
     return super.create(entity);
   }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/AbstractMigrationService.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/AbstractMigrationService.java
@@ -107,7 +107,7 @@ public abstract class AbstractMigrationService<T>  extends AbstractStorage {
       //
       afterMigration();
     } catch (Exception e) {
-      LOG.error("Failed to run migration data from JCR to Mysql.", e);
+      LOG.error("Failed to run data migration from JCR to RDBMS.", e);
     } finally {
       RequestLifeCycle.end();
     }
@@ -298,7 +298,7 @@ public abstract class AbstractMigrationService<T>  extends AbstractStorage {
     EntityManager em = entityManagerService.getEntityManager();
     if (!em.getTransaction().isActive()) {
       em.getTransaction().begin();
-      LOG.debug("started new transaction");
+      LOG.debug("new transaction started");
       return true;
     }
     return false;

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/IdentityMigrationService.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/IdentityMigrationService.java
@@ -35,6 +35,7 @@ import org.exoplatform.management.jmx.annotations.Property;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.addons.search.ProfileIndexingServiceConnector;
 import org.exoplatform.social.addons.storage.RDBMSIdentityStorageImpl;
+import org.exoplatform.social.addons.updater.utils.IdentityUtil;
 import org.exoplatform.social.core.chromattic.entity.DisabledEntity;
 import org.exoplatform.social.core.chromattic.entity.IdentityEntity;
 import org.exoplatform.social.core.chromattic.entity.ProfileEntity;
@@ -284,15 +285,17 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
 
   private Identity migrateIdentity(Node node, String jcrId) throws Exception {
     String providerId = node.getProperty("soc:providerId").getString();
-    String remoteId = node.getProperty("soc:remoteId").getString();
+    // The node name is the identity id.
+    // Node name is soc:<name>, only the <name> is relevant
+    String name = IdentityUtil.getIdentityName(node.getName());
 
-    Identity identity = identityStorage.findIdentity(providerId, remoteId);
+    Identity identity = identityStorage.findIdentity(providerId, name);
     if (identity != null) {
       LOG.info("Identity with providerId = " + identity.getProviderId() + " and remoteId=" + identity.getRemoteId() + " has already been migrated.");
       return identity;
     }
 
-    identity = new Identity(providerId, remoteId);
+    identity = new Identity(providerId, name);
     identity.setDeleted(node.getProperty("soc:isDeleted").getBoolean());
 
     if (node.isNodeType("soc:isDisabled")) {

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/IdentityMigrationService.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/IdentityMigrationService.java
@@ -139,12 +139,12 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
               offset++;
               Node identityNode = nodeIter.nextNode();
               String identityName = identityNode.getName();
+              String jcrid = identityNode.getUUID();
               transactionList.add(identityName);
 
-              LOG.info(String.format("|  \\ START::identity number: %s/%s (%s identity)", offset, totalIdentities, identityName));
+              LOG.info("|  \\ START::identity number: {}/{} node_name={} uuid={}", offset, totalIdentities, identityName, jcrid);
               long t1 = System.currentTimeMillis();
 
-              String jcrid = identityNode.getUUID();
               try {
                 Identity identity = migrateIdentity(identityNode, jcrid);
 
@@ -152,13 +152,14 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
                   String newId = identity.getId();
                   identity.setId(jcrid);
                   broadcastListener(identity, newId);
+                  LOG.info("|      Identity migrated jcr_uid={} id={}", jcrid, newId);
                 }
                 numberSuccessful++;
               } catch (Exception ex) {
                 identitiesMigrateFailed.add(identityName);
-                LOG.error("Error while migrate identity " + identityName, ex);
+                LOG.error(String.format("Error during migration of identity node_name=%s uuid=%s", identityName, jcrid), ex);
               }
-              LOG.info(String.format("|  / END::identity number %s (%s identity) consumed %s(ms)", offset, identityNode.getName(), System.currentTimeMillis() - t1));
+              LOG.info("|  / END::identity number {} node_name={} duration_ms={}", offset, identityNode.getName(), System.currentTimeMillis() - t1);
             }
           }
 
@@ -179,9 +180,9 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
 
     numberIdentities = offset;
     if (identitiesMigrateFailed.size() > 0) {
-      LOG.info(String.format("| / END::Identity migration failed for (%s) identity(s)", identitiesMigrateFailed.size()));
+      LOG.info("| / END::Identity migration failed for ({}) identity(s)", identitiesMigrateFailed.size());
     }
-    LOG.info(String.format("|// END::Identity migration for (%s) identity(s) consumed %s(ms)", numberSuccessful, System.currentTimeMillis() - t));
+    LOG.info("|// END::Identity migration for ({}) identity(s) duration_ms={}", numberSuccessful, System.currentTimeMillis() - t);
 
     LOG.info("| \\ START::Re-indexing identity(s) ---------------------------------");
     IndexingService indexingService = CommonsUtils.getService(IndexingService.class);
@@ -231,7 +232,7 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
               offset++;
               Node node = nodeIter.nextNode();
               timePerIdentity = System.currentTimeMillis();
-              LOG.info(String.format("|  \\ START::cleanup Identity number: %s/%s (%s identity)", offset, totalIdentities, node.getName()));
+              LOG.info("|  \\ START::cleanup Identity number: {}/{} name={}", offset, totalIdentities, node.getName());
 
               String name = node.getName();
               if (!MigrationContext.isForceCleanup() && (MigrationContext.getIdentitiesCleanupConnectionFailed().contains(name)
@@ -265,7 +266,7 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
                 getSession().getJCRSession().refresh(false);
               }
 
-              LOG.info(String.format("|  / END::cleanup (%s identity) consumed time %s(ms)", node.getName(), System.currentTimeMillis() - timePerIdentity));
+              LOG.info("|  / END::cleanup Identity ({}) identities duration_ms={}", node.getName(), System.currentTimeMillis() - timePerIdentity);
             }
           }
 
@@ -277,9 +278,9 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
     } finally {
       MigrationContext.setIdentitiesCleanupFailed(identitiesCleanupFailed);
       if (identitiesCleanupFailed.size() > 0) {
-        LOG.warn("Cleanup failed for " + identitiesCleanupFailed.size() + " identities");
+        LOG.warn("Cleanup failed for {} identities", identitiesCleanupFailed.size());
       }
-      LOG.info(String.format("| / END::cleanup Identities migration for (%s) identity consumed %s(ms)", offset, System.currentTimeMillis() - t));
+      LOG.info("| / END::cleanup ({}) identities duration_ms={}", offset, System.currentTimeMillis() - t);
     }
   }
 
@@ -291,7 +292,7 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
 
     Identity identity = identityStorage.findIdentity(providerId, name);
     if (identity != null) {
-      LOG.info("Identity with providerId = " + identity.getProviderId() + " and remoteId=" + identity.getRemoteId() + " has already been migrated.");
+      LOG.info("Identity with provider_id={} and remote_id={} has already been migrated. Identity id={} will be used.", identity.getProviderId(), identity.getRemoteId(), identity.getId());
       return identity;
     }
 

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/RDBMSMigrationManager.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/RDBMSMigrationManager.java
@@ -346,15 +346,15 @@ public class RDBMSMigrationManager implements Startable {
             }
           }
 
-          LOG.info(String.format("Migration job has done, total time is %s (ms)", (System.currentTimeMillis() - startTime)));
-          LOG.info(String.format("Migration space in %s (ms)", timeToMigrateSpaces));
-          LOG.info(String.format("- Number space failed: %s", MigrationContext.getSpaceMigrateFailed().size()));
+          LOG.info("Migration job done, total time is duration_ms={}", (System.currentTimeMillis() - startTime));
+          LOG.info("Migration - Space in duration_ms={}", timeToMigrateSpaces);
+          LOG.info("- Number space failed: {}", MigrationContext.getSpaceMigrateFailed().size());
           if (!MigrationContext.getSpaceMigrateFailed().isEmpty()) {
             LOG.warn("- space failed: " + MigrationContext.getSpaceMigrateFailed());
           }
 
-          LOG.info(String.format("Migration identities in %s (ms)", timeToMigrateIdentities));
-          LOG.info(String.format("- Number identities failed: %s", MigrationContext.getIdentitiesMigrateFailed().size()));
+          LOG.info("Migration - Identities duration_ms={}", timeToMigrateIdentities);
+          LOG.info("- Number identities failed: {}", MigrationContext.getIdentitiesMigrateFailed().size());
           if (!MigrationContext.getIdentitiesMigrateFailed().isEmpty()) {
             LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateFailed());
           }
@@ -362,39 +362,39 @@ public class RDBMSMigrationManager implements Startable {
           if (!MigrationContext.getIdentitiesMigrateFailed().isEmpty()) {
             LOG.info("We could not continue migration job because the identities migration was failed");
           } else {
-            LOG.info(String.format("Migration relationships in %s (ms)", timeToMigrateConnections));
-            LOG.info(String.format("- migrate failed for %s user(s)", MigrationContext.getIdentitiesMigrateConnectionFailed().size()));
+            LOG.info("Migration - Relationships duration_ms={}", timeToMigrateConnections);
+            LOG.info("- migration failed for {} user(s)", MigrationContext.getIdentitiesMigrateConnectionFailed().size());
             if (!MigrationContext.getIdentitiesMigrateConnectionFailed().isEmpty()) {
               LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateConnectionFailed());
             }
 
-            LOG.info(String.format("Migration activities in %s (ms)", timeToMigrateActivities));
-            LOG.info(String.format("- migrate failed for %s user(s)", MigrationContext.getIdentitiesMigrateActivityFailed().size()));
+            LOG.info("Migration - Activities duration_ms={}", timeToMigrateActivities);
+            LOG.info("- migration failed for {} user(s)", MigrationContext.getIdentitiesMigrateActivityFailed().size());
             if (!MigrationContext.getIdentitiesMigrateActivityFailed().isEmpty()) {
               LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateActivityFailed());
             }
 
             // Cleanup
-            LOG.info(String.format("Cleanup relationship in %s (ms)", timeToCleanupConnections));
-            LOG.info(String.format("- cleanup connection failed for %s user(s)", MigrationContext.getIdentitiesCleanupConnectionFailed().size()));
+            LOG.info("Cleanup - Relationships duration_ms={}", timeToCleanupConnections);
+            LOG.info("- connection cleanup failed for {} user(s)", MigrationContext.getIdentitiesCleanupConnectionFailed().size());
             if (!MigrationContext.getIdentitiesCleanupConnectionFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupConnectionFailed());
             }
 
-            LOG.info(String.format("Cleanup activities in %s (ms)", timeToCleanupActivities));
-            LOG.info(String.format("- cleanup activities failed for %s identity(s)", MigrationContext.getIdentitiesCleanupActivityFailed().size()));
+            LOG.info("Cleanup - Activities duration_ms={}", timeToCleanupActivities);
+            LOG.info("- activities cleanup failed for {} identity(s)", MigrationContext.getIdentitiesCleanupActivityFailed().size());
             if (!MigrationContext.getIdentitiesCleanupActivityFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupActivityFailed());
             }
 
-            LOG.info(String.format("Cleanup identities in %s (ms)", timeToCleanupIdentities));
-            LOG.info(String.format("- cleanup failed for %s identity(s)", MigrationContext.getIdentitiesCleanupFailed().size()));
+            LOG.info("Cleanup - Identities duration_ms={}", timeToCleanupIdentities);
+            LOG.info("- cleanup failed for {} identity(s)", MigrationContext.getIdentitiesCleanupFailed().size());
             if (!MigrationContext.getIdentitiesCleanupFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupFailed());
             }
 
-            LOG.info(String.format("Cleanup spaces in %s (ms)", timeToCleanupSpaces));
-            LOG.info(String.format("- cleanup failed for %s space(s)", MigrationContext.getSpaceCleanupFailed().size()));
+            LOG.info("Cleanup - Spaces in duration_ms={}", timeToCleanupSpaces);
+            LOG.info("- cleanup failed for {} space(s)", MigrationContext.getSpaceCleanupFailed().size());
             if (!MigrationContext.getSpaceCleanupFailed().isEmpty()) {
               LOG.warn("- space cleanup failed: " + MigrationContext.getSpaceCleanupFailed());
             }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/RelationshipMigrationService.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/RelationshipMigrationService.java
@@ -119,7 +119,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
             String identityName = identityNode.getName();
             transactionList.add(identityName);
 
-            LOG.info(String.format("|  \\ START::user number: %s/%s (%s user)", offset, totalIdentities, identityNode.getName()));
+            LOG.info("|  \\ START::user number: {}/{} name={}", offset, totalIdentities, identityNode.getName());
             long t1 = System.currentTimeMillis();
 
             Node relationshipNode = identityNode.getNode("soc:relationship");
@@ -166,7 +166,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
               nodeIter = getIdentityNodes(offset, LIMIT_THRESHOLD);
             }
 
-            LOG.info(String.format("|  / END::user number %s (%s user) with %s relationship(s) user consumed %s(ms)", relationshipNo, identityNode.getName(), relationshipNo, System.currentTimeMillis() - t1));
+            LOG.info("|  / END::user number {} name={} with {} relationship(s) duration_ms={}", relationshipNo, identityNode.getName(), relationshipNo, System.currentTimeMillis() - t1);
           }
         }
 
@@ -181,7 +181,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
       }
     }
 
-    LOG.info(String.format("| / END::Relationships migration for (%s) user(s) with %s relationship(s) consumed %s(ms)", offset, total, System.currentTimeMillis() - t));
+    LOG.info("| / END::Relationships migration for ({}) user(s) with {} relationship(s) duration_ms={}", offset, total, System.currentTimeMillis() - t);
     RequestLifeCycle.begin(PortalContainer.getInstance());
 
     LOG.info("| \\ START::Re-indexing identity(s) ---------------------------------");
@@ -234,7 +234,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
       }
       
       if(doneConnectionNo % LIMIT_THRESHOLD == 0) {
-        LOG.info(String.format("|     - BATCH MIGRATION::relationship number: %s (%s user)", doneConnectionNo,  userName));
+        LOG.info("|     - BATCH MIGRATION::relationship number: {} user_name={}", doneConnectionNo,  userName);
         endTx(true);
         entityManagerService.endRequest(PortalContainer.getInstance());
         entityManagerService.startRequest(PortalContainer.getInstance());
@@ -284,7 +284,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
         transactionList.add(node.getName());
         offset++;
 
-        LOG.info(String.format("|  \\ START::cleanup Relationship of user number: %s/%s (%s user)", offset, totalIdentities, node.getName()));
+        LOG.info("|  \\ START::cleanup User Relationship number: {}/{} user_name={}", offset, totalIdentities, node.getName());
         IdentityEntity identityEntity = _findById(IdentityEntity.class, node.getUUID());
         
         Collection<RelationshipEntity> entities = identityEntity.getRelationship().getRelationships().values();
@@ -296,7 +296,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
         entities = identityEntity.getReceiver().getRelationships().values();
         removeRelationshipEntity(entities);
         
-        LOG.info(String.format("|  / END::cleanup (%s user) consumed time %s(ms)", node.getName(), System.currentTimeMillis() - timePerUser));
+        LOG.info("|  / END::cleanup User Relationship user_name={} duration_ms={}", node.getName(), System.currentTimeMillis() - timePerUser);
         
         timePerUser = System.currentTimeMillis();
         if(offset % LIMIT_THRESHOLD == 0) {
@@ -312,7 +312,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
           transactionList = new ArrayList<>();
         }
       }
-      LOG.info(String.format("| / END::cleanup Relationships migration for (%s) user consumed %s(ms)", offset, System.currentTimeMillis() - t));
+      LOG.info("| / END::cleanup User Relationships for {} users duration_ms={}", offset, System.currentTimeMillis() - t);
     } finally {
       try {
         getSession().save();
@@ -335,7 +335,7 @@ public class RelationshipMigrationService extends AbstractMigrationService<Relat
         getSession().remove(relationshipEntity);
         ++offset;
         if (offset % LIMIT_REMOVED_THRESHOLD == 0) {
-          LOG.info(String.format("|     - BATCH CLEANUP::relationship number: %s", offset));
+          LOG.info("|     - BATCH CLEANUP::relationship number: {}", offset);
           getSession().save();
         }
       }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/SpaceMigrationService.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/SpaceMigrationService.java
@@ -124,7 +124,7 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
 
             spaceInTransaction.add(spaceName);
 
-            LOG.info(String.format("|  \\ START::space number: %s/%s (%s space)", offset, totalSpace, spaceName));
+            LOG.info("|  \\ START::space migration number: {}/{} name={}", offset, totalSpace, spaceName);
             long t1 = System.currentTimeMillis();
 
             try {
@@ -135,7 +135,7 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
               LOG.error("Error while migrate the space " + spaceName, ex);
               spaceMigrateFailed.add(spaceName);
             }
-            LOG.info(String.format("|  / END::space number %s (%s space) consumed %s(ms)", offset, spaceNode.getName(), System.currentTimeMillis() - t1));
+            LOG.info("|  / END::space migration number {} name={} duration_ms={}", offset, spaceNode.getName(), System.currentTimeMillis() - t1)  ;
           }
         }
 
@@ -153,9 +153,9 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
     RequestLifeCycle.begin(PortalContainer.getInstance());
 
     if (numberFailed > 0) {
-      LOG.info(String.format("|   Space migration failed for (%s) space(s)", numberFailed));
+      LOG.info("|   Space migration failed for ({}) space(s)", numberFailed);
     }
-    LOG.info(String.format("| / END::Space migration for (%s) space(s) consumed %s(ms)", numberSuccessful, System.currentTimeMillis() - t));
+    LOG.info("| / END::Space migration of ({}) space(s) duration_ms={}", numberSuccessful, System.currentTimeMillis() - t);
 
     LOG.info("| \\ START::Re-indexing space(s) ---------------------------------");
     //To be sure all of the space will be indexed in ES after migrated
@@ -251,7 +251,7 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
         }
         transactionList.add(name);
 
-        LOG.info(String.format("|  \\ START::cleanup Space number: %s/%s (%s space)", offset, totalSpace, node.getName()));
+        LOG.info("|  \\ START::cleanup space number: {}/{} name={}", offset, totalSpace, node.getName());
 
         try {
 
@@ -275,7 +275,7 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
           LOG.error("Error while remove the space " + name, ex);
         }
 
-        LOG.info(String.format("|  / END::cleanup (%s space) consumed time %s(ms)", node.getName(), System.currentTimeMillis() - timePerSpace));
+        LOG.info("|  / END::cleanup space name={} duration_ms={}", node.getName(), System.currentTimeMillis() - timePerSpace);
         
         timePerSpace = System.currentTimeMillis();
         if(offset % REMOVE_LIMIT_THRESHOLD == 0) {
@@ -292,7 +292,7 @@ public class SpaceMigrationService extends AbstractMigrationService<Space> {
           transactionList = new ArrayList<>();
         }
       }
-      LOG.info(String.format("| / END::cleanup Spaces migration for (%s) space consumed %s(ms)", offset, System.currentTimeMillis() - t));
+      LOG.info("| / END::cleanup ({}) spaces duration_ms={}", offset, System.currentTimeMillis() - t);
     } finally {
       try {
         getSession().save();

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/listener/RelationshipActivityUpdaterListener.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/listener/RelationshipActivityUpdaterListener.java
@@ -47,7 +47,7 @@ public class RelationshipActivityUpdaterListener extends Listener<ExoSocialActiv
     if (RELATIONSHIP_ACTIVITY_TYPE.equals(activity.getType())) {
       Identity identity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, activity.getStreamOwner());
       identityStorage.updateProfileActivityId(identity, newActivityId, Profile.AttachedActivityType.RELATIONSHIP);
-      LOG.info(String.format("Migration the relationship activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), newActivityId));
+      LOG.info("Migrate the relationship activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), newActivityId);
     }
     
   }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/listener/SpaceActivityUpdaterListener.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/listener/SpaceActivityUpdaterListener.java
@@ -47,7 +47,7 @@ public class SpaceActivityUpdaterListener extends Listener<ExoSocialActivity, St
     if (SPACE_ACTIVITY_TYPE.equals(activity.getType())) {
       Identity spaceIdentity = identityStorage.findIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner());
       identityStorage.updateProfileActivityId(spaceIdentity, newActivityId, Profile.AttachedActivityType.SPACE);
-      LOG.info(String.format("Migration the space activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), newActivityId));
+      LOG.info("Migrate the space activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), newActivityId);
     }
   }
 }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/listener/UserProfileActivityUpdaterListener.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/listener/UserProfileActivityUpdaterListener.java
@@ -47,7 +47,7 @@ public class UserProfileActivityUpdaterListener extends Listener<ExoSocialActivi
     if (PROFILE_ACTIVITY_TYPE.equals(activity.getType())) {
       Identity identity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, activity.getStreamOwner());
       identityStorage.updateProfileActivityId(identity, newActivityId, Profile.AttachedActivityType.USER);
-      LOG.info(String.format("Migration the profile activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), newActivityId));
+      LOG.info("Migrate the profile activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), newActivityId);
     }
     
   }

--- a/lib/src/main/java/org/exoplatform/social/addons/updater/utils/IdentityUtil.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/updater/utils/IdentityUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2003-2015 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.addons.updater.utils;
+
+import org.chromattic.ext.format.BaseEncodingObjectFormatter;
+
+/**
+ * Created by The eXo Platform SAS
+ * Author : eXoPlatform
+ *          exo@exoplatform.com
+ * Oct 17, 2016
+ */
+public class IdentityUtil {
+    private static final BaseEncodingObjectFormatter formatter = new BaseEncodingObjectFormatter();
+
+    public static String getIdentityName(String nodeName) {
+        String name = nodeName.substring(4);
+
+        return formatter.decodeNodeName(null, name);
+    }
+}

--- a/lib/src/test/java/org/exoplatform/social/addons/concurrency/AsynMigrateActivitiesTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/concurrency/AsynMigrateActivitiesTest.java
@@ -40,7 +40,7 @@ public class AsynMigrateActivitiesTest extends AbstractAsynMigrationTest {
     // create jcr data
     LOG.info("Create connection for root,john,mary and demo");
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
 
@@ -126,7 +126,7 @@ public class AsynMigrateActivitiesTest extends AbstractAsynMigrationTest {
     begin();
 
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
 

--- a/lib/src/test/java/org/exoplatform/social/addons/concurrency/MigrationTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/concurrency/MigrationTest.java
@@ -176,7 +176,7 @@ public class MigrationTest extends BaseCoreTest {
 
   public void testMigrateActivityWithMention() throws Exception {
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
     johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
 

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/ActivityManagerMysqlTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/ActivityManagerMysqlTest.java
@@ -1318,7 +1318,7 @@ public class ActivityManagerMysqlTest extends AbstractCoreTest {
     assertEquals(0, demoActivityFeed.load(0, 10).length);
     
     ExoSocialActivity comment = new ExoSocialActivityImpl();
-    comment.setTitle("mary mention @demo @john");
+    comment.setTitle("mary mention @demo @john.test");
     comment.setUserId(maryIdentity.getId());
     activityManager.saveComment(activity, comment);
     
@@ -1439,8 +1439,8 @@ public class ActivityManagerMysqlTest extends AbstractCoreTest {
       space.setPriority(Space.INTERMEDIATE_PRIORITY);
       space.setGroupId(SpaceUtils.SPACE_GROUP + "/" + space.getPrettyName());
       space.setUrl(space.getPrettyName());
-      String[] managers = new String[] { "demo", "john" };
-      String[] members = new String[] { "raul", "ghost", "demo", "john" };
+      String[] managers = new String[] { "demo", "john.test" };
+      String[] members = new String[] { "raul", "ghost", "demo", "john.test" };
       String[] invitedUsers = new String[] { "mary", "paul"};
       String[] pendingUsers = new String[] { "jame"};
       space.setInvitedUsers(invitedUsers);

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/RDBMSActivityStorageImplTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/RDBMSActivityStorageImplTest.java
@@ -568,7 +568,7 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
   @MaxQueryNumber(1281)
   public void testMentionersAndCommenters() throws Exception {
     ExoSocialActivity activity = createActivity(1);
-    activity.setTitle("hello @demo @john");
+    activity.setTitle("hello @demo @john.test");
     activityStorage.saveActivity(rootIdentity, activity);
     tearDownActivityList.add(activity);
     
@@ -649,7 +649,7 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
     activity.setBody("Body of "+ activity.getTitle());
     activity.setBodyId("BodyId of "+ activity.getTitle());
     activity.setLikeIdentityIds(new String[]{"demo", "mary"});
-    activity.setMentionedIds(new String[]{"demo", "john"});
+    activity.setMentionedIds(new String[]{"demo", "john.test"});
     activity.setCommentedIds(new String[]{});
     activity.setReplyToId(new String[]{});
     activity.setAppId("AppID");

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/RDBMSRelationshipManagerTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/RDBMSRelationshipManagerTest.java
@@ -1100,7 +1100,7 @@ public class RDBMSRelationshipManagerTest extends AbstractCoreTest {
   public void testGetManyRelationshipsByIdentityId() throws Exception {
     String providerId = OrganizationIdentityProvider.NAME;
 
-    Identity sender = identityManager.getOrCreateIdentity(providerId,"john");
+    Identity sender = identityManager.getOrCreateIdentity(providerId,"john.test");
     identityManager.saveIdentity(sender);
     assertNotNull(sender.getId());
 

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/RelationshipStorageTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/RelationshipStorageTest.java
@@ -71,7 +71,7 @@ public class RelationshipStorageTest extends AbstractCoreTest {
     identityStorage = (IdentityStorage) getContainer().getComponentInstanceOfType(IdentityStorage.class);
     assertNotNull("identityManger must not be null", identityStorage);
     rootIdentity = new Identity(OrganizationIdentityProvider.NAME, "root");
-    johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john");
+    johnIdentity = new Identity(OrganizationIdentityProvider.NAME, "john.test");
     maryIdentity = new Identity(OrganizationIdentityProvider.NAME, "mary");
     demoIdentity = new Identity(OrganizationIdentityProvider.NAME, "demo");
     identityStorage.saveIdentity(rootIdentity);
@@ -193,8 +193,8 @@ public class RelationshipStorageTest extends AbstractCoreTest {
     assertEquals("listIdentities.size() must return: 2", 2, listIdentities.size());
 
     // Check john has avatar
-    assertNotNull(getInList(listIdentities, "john").getProfile());
-    assertNotNull(getInList(listIdentities, "john").getProfile().getAvatarUrl());
+    assertNotNull(getInList(listIdentities, "john.test").getProfile());
+    assertNotNull(getInList(listIdentities, "john.test").getProfile().getAvatarUrl());
 
     // Check mary hasn't avatar but empty profile
     assertNotNull(getInList(listIdentities, "mary").getProfile());
@@ -540,8 +540,8 @@ public class RelationshipStorageTest extends AbstractCoreTest {
     demoIdentity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, demoIdentity.getRemoteId());
 
     // Check john has avatar
-    assertNotNull(getInList(listIdentities, "john").getProfile());
-    assertNotNull(getInList(listIdentities, "john").getProfile().getAvatarUrl());
+    assertNotNull(getInList(listIdentities, "john.test").getProfile());
+    assertNotNull(getInList(listIdentities, "john.test").getProfile().getAvatarUrl());
 
     // Check mary hasn't avatar but empty profile
     assertNotNull(getInList(listIdentities, "mary").getProfile());

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/dao/StreamItemDAOTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/dao/StreamItemDAOTest.java
@@ -341,7 +341,7 @@ public class StreamItemDAOTest extends BaseCoreTest {
     activity.setBody("Body of " + activity.getTitle());
     activity.setBodyId("BodyId of " + activity.getTitle());
     activity.setLikeIdentityIds(new String[] { "demo", "mary" });
-    activity.setMentionedIds(new String[] { "demo", "john" });
+    activity.setMentionedIds(new String[] { "demo", "john.test" });
     activity.setCommentedIds(new String[] {});
     activity.setReplyToId(new String[] {});
     activity.setAppId("AppID");

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/listener/ExampleActivityUpdaterListener.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/listener/ExampleActivityUpdaterListener.java
@@ -30,9 +30,9 @@ public class ExampleActivityUpdaterListener extends Listener<ExoSocialActivity, 
   public void onEvent(Event<ExoSocialActivity, String> event) throws Exception {
     ExoSocialActivity activity = event.getSource();
     if (activity.isComment()) {
-      LOG.info(String.format("Migration the comment '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), event.getData()));
+      LOG.info("Migration of comment title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), event.getData());
     } else {
-      LOG.info(String.format("Migration the activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), event.getData()));
+      LOG.info("Migration of activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), event.getData());
     }
   }
 }

--- a/lib/src/test/java/org/exoplatform/social/addons/test/AbstractCoreTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/test/AbstractCoreTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractCoreTest extends BaseExoTestCase {
     identityStorage = getService(RDBMSIdentityStorageImpl.class);
     //
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
   }

--- a/lib/src/test/java/org/exoplatform/social/addons/test/BaseCoreTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/test/BaseCoreTest.java
@@ -116,7 +116,7 @@ public abstract class BaseCoreTest extends BaseExoTestCase {
     entityManagerService = getService(EntityManagerService.class);
     //
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
   }

--- a/lib/src/test/java/org/exoplatform/social/addons/test/IdentityUtilTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/test/IdentityUtilTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2003-2016 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.addons.test;
+
+import org.exoplatform.commons.testing.BaseExoTestCase;
+import org.exoplatform.social.addons.updater.utils.IdentityUtil;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class IdentityUtilTest extends BaseExoTestCase {
+    public void testNameConvertion() {
+        assertEquals("name", IdentityUtil.getIdentityName("soc:name"));
+        assertEquals("test.name", IdentityUtil.getIdentityName("soc:name%02test"));
+    }
+}

--- a/lib/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
+++ b/lib/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
@@ -184,7 +184,7 @@
                 </value>
                 <value>
                   <object type="org.exoplatform.services.organization.OrganizationConfig$User">
-                    <field  name="userName"><string>john</string></field>
+                    <field  name="userName"><string>john.test</string></field>
                     <field  name="password"><string>gtn</string></field>
                     <field  name="firstName"><string>John</string></field>
                     <field  name="lastName"><string>Anthony</string></field>


### PR DESCRIPTION
- Try to detect the incoherent nodes with name != remote_id
  - if an incoherence is found, declare the node in error for the migration. It's seems it's a case not supposed to happen but we found one node in this case during our tests. The consequences are the activities are not correctly migrated so we need to anticipate it.
- Add/Review logs to help to diagnose migration problems
- Remove the String.format used to build the log messages when it's not necessary
