### PR TITLE
SOC-5520 : reindex only profiles and not all identities when launching a full reindexation on profile type

### DIFF
--- a/lib/src/main/java/org/exoplatform/social/addons/search/ProfileIndexingServiceConnector.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/search/ProfileIndexingServiceConnector.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.json.simple.JSONObject;
 
 import org.exoplatform.addons.es.domain.Document;
@@ -134,7 +135,7 @@ import org.exoplatform.social.core.relationship.model.Relationship;
 
   @Override
   public List<String> getAllIds(int offset, int limit) {
-    List<Long> ids = identityDAO.getAllIds(offset, limit);
+    List<Long> ids = identityDAO.getAllIdsByProvider(OrganizationIdentityProvider.NAME, offset, limit);
 
     if (ids == null || ids.isEmpty()) {
       return new ArrayList<>();

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/IdentityDAO.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/IdentityDAO.java
@@ -36,4 +36,6 @@ public interface IdentityDAO extends GenericDAO<IdentityEntity, Long> {
   ListAccess<IdentityEntity> findIdentities(ExtendProfileFilter filter);
 
   List<Long> getAllIds(int offset, int limit);  
+
+  List<Long> getAllIdsByProvider(String providerId, int offset, int limit);
 }

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/IdentityDAOImpl.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/dao/jpa/IdentityDAOImpl.java
@@ -78,6 +78,17 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
   }
 
   @Override
+  public List<Long> getAllIdsByProvider(String providerId, int offset, int limit) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("SocIdentity.getAllIdsByProvider", Long.class);
+    query.setParameter("providerId", providerId);
+    if (limit > 0) {
+      query.setFirstResult(offset);
+      query.setMaxResults(limit);
+    }
+    return query.getResultList();
+  }
+
+  @Override
   public ListAccess<IdentityEntity> findIdentities(ExtendProfileFilter filter) {
     ProfileQueryBuilder qb = ProfileQueryBuilder.builder()
             .withFilter(filter);

--- a/lib/src/main/java/org/exoplatform/social/addons/storage/entity/IdentityEntity.java
+++ b/lib/src/main/java/org/exoplatform/social/addons/storage/entity/IdentityEntity.java
@@ -66,6 +66,10 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         @NamedQuery(
                 name = "SocIdentity.getAllIds",
                 query = "SELECT i.id FROM SocIdentityEntity i WHERE i.deleted = FALSE AND i.enabled = TRUE"
+        ),
+        @NamedQuery(
+                name = "SocIdentity.getAllIdsByProvider",
+                query = "SELECT i.id FROM SocIdentityEntity i WHERE i.deleted = FALSE AND i.enabled = TRUE AND i.providerId = :providerId"
         )
 })
 public class IdentityEntity {

--- a/lib/src/test/java/org/exoplatform/social/addons/storage/dao/IdentityDAOTest.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/storage/dao/IdentityDAOTest.java
@@ -24,6 +24,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.addons.storage.entity.IdentityEntity;
 import org.exoplatform.social.addons.test.BaseCoreTest;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.junit.Test;
 
 import javax.persistence.EntityExistsException;
@@ -55,6 +56,51 @@ public class IdentityDAOTest extends BaseCoreTest {
     }
 
     super.tearDown();
+  }
+
+  public void testGetAllIds() {
+    // Given
+    IdentityEntity identityUser1 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "user1"));
+    IdentityEntity identityUser2 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "user2"));
+    IdentityEntity identitySpace1 = identityDAO.create(createIdentity(SpaceIdentityProvider.NAME, "space1"));
+
+    // When
+    List<Long> allIds = identityDAO.getAllIds(0, 0);
+
+    // Then
+    assertNotNull(allIds);
+    assertEquals(3, allIds.size());
+    assertTrue(allIds.contains(identityUser1.getId()));
+    assertTrue(allIds.contains(identityUser2.getId()));
+    assertTrue(allIds.contains(identitySpace1.getId()));
+
+    deleteIdentities.add(identityUser1);
+    deleteIdentities.add(identityUser2);
+    deleteIdentities.add(identitySpace1);
+  }
+
+  public void testGetAllIdsByProvider() {
+    // Given
+    IdentityEntity identityUser1 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "user1"));
+    IdentityEntity identityUser2 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "user2"));
+    IdentityEntity identitySpace1 = identityDAO.create(createIdentity(SpaceIdentityProvider.NAME, "space1"));
+
+    // When
+    List<Long> allOrganizationIds = identityDAO.getAllIdsByProvider(OrganizationIdentityProvider.NAME, 0, 0);
+    List<Long> allSpaceIds = identityDAO.getAllIdsByProvider(SpaceIdentityProvider.NAME, 0, 0);
+
+    // Then
+    assertNotNull(allOrganizationIds);
+    assertEquals(2, allOrganizationIds.size());
+    assertTrue(allOrganizationIds.contains(identityUser1.getId()));
+    assertTrue(allOrganizationIds.contains(identityUser2.getId()));
+    assertNotNull(allSpaceIds);
+    assertEquals(1, allSpaceIds.size());
+    assertTrue(allSpaceIds.contains(identitySpace1.getId()));
+
+    deleteIdentities.add(identityUser1);
+    deleteIdentities.add(identityUser2);
+    deleteIdentities.add(identitySpace1);
   }
 
   public void testSaveNewIdentity() {
@@ -120,9 +166,13 @@ public class IdentityDAOTest extends BaseCoreTest {
   }
 
   private IdentityEntity createIdentity() {
+    return createIdentity(OrganizationIdentityProvider.NAME, "usera");
+  }
+
+  private IdentityEntity createIdentity(String providerId, String remoteId) {
     IdentityEntity entity = new IdentityEntity();
-    entity.setProviderId(OrganizationIdentityProvider.NAME);
-    entity.setRemoteId("usera");
+    entity.setProviderId(providerId);
+    entity.setRemoteId(remoteId);
     entity.setEnabled(true);
     entity.setDeleted(false);
     return entity;

--- a/lib/src/test/java/org/exoplatform/social/addons/test/InitContainerTestSuite.java
+++ b/lib/src/test/java/org/exoplatform/social/addons/test/InitContainerTestSuite.java
@@ -17,6 +17,7 @@
 package org.exoplatform.social.addons.test;
 
 import org.exoplatform.social.addons.storage.RelationshipStorageTest;
+import org.exoplatform.social.addons.storage.dao.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runners.Suite.SuiteClasses;
@@ -29,11 +30,10 @@ import org.exoplatform.social.addons.storage.RDBMSActivityStorageImplTest;
 import org.exoplatform.social.addons.storage.RDBMSRelationshipManagerTest;
 import org.exoplatform.social.addons.storage.RDBMSSpaceStorageTest;
 import org.exoplatform.social.addons.storage.SpaceActivityMySqlPublisherTest;
-import org.exoplatform.social.addons.storage.dao.ActivityDAOTest;
-import org.exoplatform.social.addons.storage.dao.StreamItemDAOTest;
 
 @SuiteClasses({
   ActivityDAOTest.class,
+  IdentityDAOTest.class,
   StreamItemDAOTest.class,
   RDBMSActivityStorageImplTest.class,
   ActivityManagerMysqlTest.class,


### PR DESCRIPTION
This PR only reindex identities from provider 'organization' when a full reindexation on profile indexing connector is launched, to avoid reindexing others identities in profile index, such as spaces.
I also added IdentityDAOTest in the test suite, in order to execute the test related to IdentityDAO in the build.